### PR TITLE
Remove debugger from code and change way of export

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -334,7 +334,6 @@ class ImageKitUppyPlugin extends Plugin {
             this.uppy.log(`uploading ${current} of ${total}`);
             var formData = new FormData();
             const metaFields = Object.keys(file.meta);
-            debugger;
             metaFields.map(key => {
                 if (key === "name") {
                     formData.append("fileName", file.meta.name.toString());
@@ -395,4 +394,4 @@ class ImageKitUppyPlugin extends Plugin {
     }
 }
 
-module.exports = ImageKitUppyPlugin
+export default ImageKitUppyPlugin


### PR DESCRIPTION
When trying to import this plugin into the Vuejs implementation, it fails because the export is not recognised. 
After the change it works, but the chrome debugger stops at the debugger location, so this has to go :)