### PR TITLE
replace append() with set() in formData filename

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -368,7 +368,7 @@ class ImageKitUppyPlugin extends Plugin {
                 }
             });
             if (!formData.get("fileName") || !formData.get("fileName").trim()) {
-                formData.append("fileName", file.name);
+                formData.set("fileName", file.name);
             }
             formData.append("publicKey", this.opts.publicKey);
             formData.append("file", file.data);


### PR DESCRIPTION
With `append()`, it would create two fields with the same name 'fileName'. `set()` overwrites any pre-existing values.